### PR TITLE
⚙️ ci: actualizar flujos de trabajo para usar npm en lugar de pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,18 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.15.1
-          run_install: false
+          cache: npm
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile=false
+        run: npm ci
 
       - name: Lint
-        run: pnpm lint
+        run: npm run lint
 
       - name: Typecheck
-        run: pnpm typecheck
+        run: npm run typecheck
 
       - name: Test
         env:
           CI: true
-        run: pnpm test
+        run: npm test

--- a/.github/workflows/publish-on-main.yml
+++ b/.github/workflows/publish-on-main.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "src/**"
       - "package.json"
-      - "pnpm-lock.yaml"
+      - "package-lock.json"
       - "tsup.config.ts"
       - "tsconfig.json"
 
@@ -16,20 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: npm ci
 
       - name: Build
-        run: pnpm build
+        run: npm run build
 
       - name: Skip if version already exists
         id: skip


### PR DESCRIPTION
- Modificado los archivos de configuración de GitHub Actions para reemplazar pnpm con npm.
- Actualizadas las tareas de instalación, linting, verificación de tipos y pruebas para utilizar npm.
- Cambiado el archivo de bloqueo de pnpm a package-lock.json en el flujo de trabajo de publicación.